### PR TITLE
Fix setter bug

### DIFF
--- a/src/plcstub.c
+++ b/src/plcstub.c
@@ -160,7 +160,7 @@ plcstub_set_impl(int32_t tag, int offset, void* value, setter_fn fn)
         return PLCTAG_ERR_BAD_PARAM;
     }
 
-    fn(t->data, offset, &value);
+    fn(t->data, offset, value);
 
     if (t->cb) {
         pdebug(PLCTAG_DEBUG_SPEW,


### PR DESCRIPTION
This was definitely a bug. I found it when testing an updated version of `refresher.go`. The stub was saving a pointer value instead of the value.
(The other pull request was the debug code I used to find this, but they're still separate changes.)