### PR TITLE
Per-tag type tracking

### DIFF
--- a/include/plcstub.h
+++ b/include/plcstub.h
@@ -12,17 +12,6 @@ typedef uintptr_t __uintptr_t;
 
 typedef void (*tag_callback_func)(int32_t tag_id, int event, int status);
 
-/* https://literature.rockwellautomation.com/idc/groups/literature/documents/pm/1756-pm020_-en-p.pdf */
-/* TODO: plc_tag_create()'s attribute list consumes a size, not a type.  Do we need this? */
-enum tag_type {
-    TAG_BOOL,
-    TAG_SINT,
-    TAG_INT,
-    TAG_DINT,
-    TAG_REAL,
-    TAG_LINT
-};
-
 struct __attribute__((packed)) metatag_t {
     uint32_t id;
     uint16_t type;

--- a/include/tagtree.h
+++ b/include/tagtree.h
@@ -2,6 +2,7 @@
 #define _TAGTREE_H_
 
 #include "plcstub.h"
+#include "types.h"
 
 #include <pthread.h>
 #include <string.h>
@@ -17,8 +18,7 @@ struct tag_tree_node {
     tag_callback_func cb;
     pthread_mutex_t mtx;
 
-    size_t elem_size;
-    size_t elem_count;
+    type_t type;
 
     /* of length (elem_size * elem_count) 
      * TODO: can this buffer ever be resized?  If not, let's make it a char[0] and save
@@ -27,7 +27,7 @@ struct tag_tree_node {
 };
 
 int
-tag_tree_insert(const char* name, size_t elem_size, size_t elem_count);
+tag_tree_insert(const char* name, type_t type);
 
 struct tag_tree_node*
 tag_tree_lookup(int32_t tag_id);

--- a/include/types.h
+++ b/include/types.h
@@ -1,0 +1,81 @@
+/* types.h
+ */
+
+#ifndef __TYPES_H__
+#define __TYPES_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* A type_t is either: 
+ * a uintptr_t containing values from TAG_BOOL to TAG_LINT;
+ * A pointer to a `struct tag array`, where the first value is TAG_ARRAY;
+ * A poitner to a `struct tag_struct`, where the first value is TAG_STRUCT
+ */
+typedef void* type_t;
+
+/* https://literature.rockwellautomation.com/idc/groups/literature/documents/pm/1756-pm020_-en-p.pdf */
+enum tag_type_e {
+    TAG_ERROR,
+    /* simple types */
+    TAG_BOOL,
+    TAG_SINT,
+    TAG_INT,
+    TAG_DINT,
+    TAG_REAL,
+    TAG_LINT,
+    /* complex types */
+    TAG_ARRAY,
+    TAG_STRUCT,
+};
+
+#define BASE_TAG_MEMBERS \
+    enum tag_type_e t;
+
+struct tag_array {
+    BASE_TAG_MEMBERS
+
+    type_t member_type;
+    uint16_t len;
+};
+
+struct tag_struct_pair {
+    char* name;
+    type_t type;
+};
+
+struct tag_struct {
+    BASE_TAG_MEMBERS
+
+    uint16_t field_cnt;
+    struct tag_struct_pair fields[0];
+};
+
+enum tag_type_e
+type_to_enum(type_t t);
+
+type_t
+type_new_simple(enum tag_type_e e);
+
+type_t
+type_new_array(uint16_t cnt, type_t member_type);
+
+type_t
+type_new_struct(int cnt, ...);
+
+type_t
+type_dup(type_t t);
+
+void
+type_free(type_t t);
+
+size_t
+type_size_bytes(type_t t);
+
+const char*
+    type_str(type_t);
+
+bool
+type_is_scalar(type_t t);
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
-add_library(plctagstub debug.c plcstub.c tagtree.c)
+add_library(plctagstub debug.c plcstub.c tagtree.c types.c)
 
 target_include_directories(plctagstub PUBLIC
                           "${CMAKE_CURRENT_SOURCE_DIR}/../include"

--- a/src/types.c
+++ b/src/types.c
@@ -1,0 +1,216 @@
+/* types.c
+ * 
+ * Routines for tag typechecking
+ */
+
+#include <err.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libplctag.h"
+#include "plcstub.h"
+#include "types.h"
+
+#define SIMPLE_TYPE(t) (type_t)(uintptr_t)(t)
+
+enum tag_type_e
+type_to_enum(type_t t)
+{
+    uintptr_t as_simple = (uintptr_t)(t);
+    enum tag_type_e* as_complex = (enum tag_type_e*)(t);
+
+    if (as_simple <= TAG_LINT) {
+        return (enum tag_type_e)(as_simple);
+    }
+    if (*as_complex == TAG_ARRAY) {
+        return TAG_ARRAY;
+    }
+    if (*as_complex == TAG_STRUCT) {
+        return TAG_STRUCT;
+    }
+    return TAG_ERROR;
+}
+
+type_t
+type_dup(type_t t)
+{
+    enum tag_type_e e = type_to_enum(t);
+
+    if (e == TAG_ARRAY) {
+        struct tag_array* a = (struct tag_array*)(t);
+        return type_new_array(a->len, a->member_type);
+    } else if (e == TAG_STRUCT) {
+        int i;
+        struct tag_struct *s, *new;
+
+        /* XXX: by my own petard, no clean way to call the variadic
+         * type_new_struct().  Duplicate the functionality here. */
+        s = (struct tag_struct*)(t);
+        new = malloc(sizeof(struct tag_struct) + s->field_cnt * sizeof(type_t));
+        if (new == NULL) {
+            err(1, "malloc");
+        }
+        new->t = TAG_STRUCT;
+        new->field_cnt = s->field_cnt;
+
+        for (i = 0; i < s->field_cnt; i++) {
+            new->fields[i].name = strdup(s->fields[i].name);
+            new->fields[i].type = type_dup(s->fields[i].type);
+        }
+
+        return new;
+    }
+    /* primitive type; return "copy" by value. */
+    return t;
+}
+
+type_t
+type_new_simple(enum tag_type_e e)
+{
+    if (e >= TAG_BOOL && e <= TAG_LINT) {
+        return (type_t)(e);
+    }
+    return (type_t)(TAG_ERROR);
+}
+
+type_t
+type_new_array(uint16_t cnt, type_t member_type)
+{
+    struct tag_array* a;
+
+    a = malloc(sizeof(struct tag_array));
+    if (a == NULL) {
+        err(1, "malloc");
+    }
+
+    a->t = TAG_ARRAY;
+    a->len = cnt;
+    a->member_type = type_dup(member_type);
+
+    return a;
+}
+
+type_t
+type_new_struct(int cnt, ...)
+{
+    int i;
+    struct tag_struct* s;
+    va_list ap;
+    va_start(ap, cnt);
+
+    s = malloc(sizeof(struct tag_struct) + cnt * sizeof(struct tag_struct_pair));
+    if (s == NULL) {
+        err(1, "malloc");
+    }
+    s->t = TAG_STRUCT;
+    s->field_cnt = cnt;
+
+    for (i = 0; i < cnt; i++) {
+        s->fields[i].name = strdup(va_arg(ap, char*));
+        s->fields[i].type = type_dup(va_arg(ap, type_t));
+    }
+
+    return s;
+}
+
+void
+type_free(type_t t)
+{
+    enum tag_type_e e = type_to_enum(t);
+    if (e == TAG_ARRAY) {
+        struct tag_array* a = (struct tag_array*)(t);
+        type_free(a->member_type);
+        free(a);
+    }
+    if (e == TAG_STRUCT) {
+        int i;
+        struct tag_struct* s = (struct tag_struct*)(t);
+        for (i = 0; i < s->field_cnt; i++) {
+            free(s->fields[i].name);
+            type_free(s->fields[i].type);
+        }
+    }
+}
+
+size_t
+type_size_bytes(type_t t)
+{
+    enum tag_type_e e = type_to_enum(t);
+    switch (e) {
+    case TAG_ERROR:
+        return 0;
+    case TAG_BOOL:
+        return 1;
+    case TAG_SINT:
+        return 1;
+    case TAG_INT:
+        return 2;
+    case TAG_DINT:
+        return 4;
+    case TAG_REAL:
+        return 4;
+    case TAG_LINT:
+        return 8;
+    case TAG_ARRAY: {
+        struct tag_array* a = (struct tag_array*)(t);
+        return type_size_bytes(a->member_type) * a->len;
+    }
+    case TAG_STRUCT: {
+        int i;
+        size_t sz = 0;
+        struct tag_struct* s = (struct tag_struct*)(t);
+        for (i = 0; i < s->field_cnt; i++) {
+            sz += type_size_bytes(s->fields[i].type);
+        }
+        return sz;
+    }
+    }
+}
+
+bool
+type_is_scalar(type_t t)
+{
+    enum tag_type_e e = type_to_enum(t);
+    switch (e) {
+    case TAG_ERROR:
+    case TAG_BOOL:
+    case TAG_SINT:
+    case TAG_INT:
+    case TAG_DINT:
+    case TAG_REAL:
+    case TAG_LINT:
+        return true;
+    case TAG_ARRAY:
+    case TAG_STRUCT:
+        return false;
+    }
+}
+
+const char*
+type_str(type_t t)
+{
+    enum tag_type_e e = type_to_enum(t);
+    switch (e) {
+    case TAG_BOOL:
+        return "BOOL";
+    case TAG_SINT:
+        return "SINT";
+    case TAG_INT:
+        return "INT";
+    case TAG_DINT:
+        return "DINT";
+    case TAG_REAL:
+        return "REAL";
+    case TAG_LINT:
+        return "LINT";
+    case TAG_ARRAY:
+        return "ARRAY";
+    case TAG_STRUCT:
+        return "STRUCT";
+    default:
+        return "ERROR";
+    }
+}

--- a/tags.inc
+++ b/tags.inc
@@ -1,0 +1,22 @@
+/* Tag file
+ *
+ * At some point, this should be auto-generated from the tags.L5X file elsewhere,
+ * or at least somewhat reflect reality.
+ *
+ * Format:
+ * DEFINE_SCALAR(name, type, val)
+ * DEFINE_ARRAY(name, type, len)
+ */
+ 
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_0", TAG_INT, 0);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_1", TAG_INT, 1);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_2", TAG_INT, 2);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_3", TAG_INT, 3);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_4", TAG_INT, 4);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_5", TAG_INT, 5);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_6", TAG_INT, 6);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_7", TAG_INT, 7);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_8", TAG_INT, 8);
+ DEFINE_SCALAR("DUMMY_AQUA_DATA_9", TAG_INT, 9);
+
+/* DEFINE_ARRAY("DUMMY_AQUA_DEFINE_ARRAY_0", TAG_BOOL, 4); */

--- a/test/03-tag_create.c
+++ b/test/03-tag_create.c
@@ -12,7 +12,7 @@ main(int argc, char** argv)
     int tid = 42;
     int ret;
 
-    plc_tag_set_debug_level(PLCTAG_DEBUG_SPEW);
+    plc_tag_set_debug_level(PLCTAG_DEBUG_DETAIL);
 
     /* Taken from src/examples/stress_test.c in libplctag. */
     const char* tag_str = "protocol=ab_eip&gateway=10.206.1.40&path=1,4&cpu=lgx&elem_size=4&elem_count=%d&name=TestBigArray[%d]&debug=4";
@@ -25,5 +25,6 @@ main(int argc, char** argv)
         printf("tag_tree_node creation successful with return value %d\n", ret);
     }
 
+    printf("Test passed!\n");
     return 0;
 }

--- a/test/04-metatag_lookup.c
+++ b/test/04-metatag_lookup.c
@@ -16,7 +16,7 @@ main(int argc, char** argv)
     int16_t s2;
     int32_t s4;
 
-    plc_tag_set_debug_level(PLCTAG_DEBUG_DETAIL);
+    plc_tag_set_debug_level(PLCTAG_DEBUG_SPEW);
 
     ret = plc_tag_read(METATAG_ID, 1000);
     if (ret != PLCTAG_STATUS_OK) {
@@ -33,14 +33,14 @@ main(int argc, char** argv)
     /* skip over type for now */
     offset += sizeof(s2);
 
-    /* size */
-    if ((s2 = plc_tag_get_int16(METATAG_ID, offset)) != 4) {
-        errx(1, "Read at offset %d: expected %d, got %d", offset, 4, s2);
+    /* size: TAG_INT == uint16_t */
+    if ((s2 = plc_tag_get_int16(METATAG_ID, offset)) != 2) {
+        errx(1, "Read at offset %d: expected %d, got %d", offset, 2, s2);
     }
     offset += sizeof(s2);
 
-    /* dims */
-    if ((s4 = plc_tag_get_int32(METATAG_ID, offset)) != 1) {
+    /* dims: for a scalar type, this should be 0 */
+    if ((s4 = plc_tag_get_int32(METATAG_ID, offset)) != 0) {
         errx(1, "Read at offset %d: expected %d, got %d", offset, 1, s4);
     }
     offset += sizeof(s4) * 3;

--- a/test/06-types.c
+++ b/test/06-types.c
@@ -1,0 +1,108 @@
+#include "assert.h"
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "debug.h"
+#include "libplctag.h"
+#include "types.h"
+
+#define SIMPLE_TYPE(t) (type_t)(uintptr_t)(t)
+
+type_t bool_literal = SIMPLE_TYPE(TAG_BOOL);
+type_t sint_literal = SIMPLE_TYPE(TAG_SINT);
+type_t int_literal = SIMPLE_TYPE(TAG_INT);
+type_t dint_literal = SIMPLE_TYPE(TAG_DINT);
+type_t real_literal = SIMPLE_TYPE(TAG_REAL);
+type_t lint_literal = SIMPLE_TYPE(TAG_LINT);
+
+type_t nonsense = (void*)("Hello world");
+
+type_t array_of_16_bools;
+type_t array_of_7_dints;
+
+type_t struct_of_three_ints;
+
+void
+test_tag_type()
+{
+    assert(type_to_enum(NULL) == TAG_ERROR);
+    assert(type_to_enum(nonsense) == TAG_ERROR);
+
+    assert(type_to_enum(bool_literal) == TAG_BOOL);
+    assert(type_to_enum(sint_literal) == TAG_SINT);
+    assert(type_to_enum(int_literal) == TAG_INT);
+    assert(type_to_enum(dint_literal) == TAG_DINT);
+    assert(type_to_enum(real_literal) == TAG_REAL);
+    assert(type_to_enum(lint_literal) == TAG_LINT);
+
+    assert(type_to_enum(array_of_16_bools) == TAG_ARRAY);
+    assert(type_to_enum(array_of_7_dints) == TAG_ARRAY);
+
+    assert(type_to_enum(struct_of_three_ints) == TAG_STRUCT);
+}
+
+void
+test_tag_size()
+{
+    assert(type_size_bytes(NULL) == 0);
+    assert(type_size_bytes(nonsense) == 0);
+
+    assert(type_size_bytes(bool_literal) == 1);
+    assert(type_size_bytes(sint_literal) == 1);
+    assert(type_size_bytes(int_literal) == 2);
+    assert(type_size_bytes(dint_literal) == 4);
+    assert(type_size_bytes(real_literal) == 4);
+    assert(type_size_bytes(lint_literal) == 8);
+
+    assert(type_size_bytes(array_of_16_bools) == 16);
+    assert(type_size_bytes(array_of_7_dints) == 4 * 7);
+
+    assert(type_size_bytes(struct_of_three_ints) == 2 * 3);
+}
+
+void
+test_tag_dup()
+{
+    type_t* t;
+
+    /* non-allocating duplications */
+    assert(type_to_enum(type_dup(bool_literal)) == TAG_BOOL);
+    assert(type_to_enum(type_dup(sint_literal)) == TAG_SINT);
+    assert(type_to_enum(type_dup(int_literal)) == TAG_INT);
+    assert(type_to_enum(type_dup(dint_literal)) == TAG_DINT);
+    assert(type_to_enum(type_dup(real_literal)) == TAG_REAL);
+    assert(type_to_enum(type_dup(lint_literal)) == TAG_LINT);
+}
+
+void
+init()
+{
+    array_of_16_bools = type_new_array(16, SIMPLE_TYPE(TAG_BOOL));
+    array_of_7_dints = type_new_array(7, SIMPLE_TYPE(TAG_DINT));
+    struct_of_three_ints = type_new_struct(3,
+        "field_1", SIMPLE_TYPE(TAG_INT),
+        "field_2", SIMPLE_TYPE(TAG_INT),
+        "field_3", SIMPLE_TYPE(TAG_INT));
+}
+
+void
+tidy()
+{
+    type_free(array_of_16_bools);
+    type_free(array_of_7_dints);
+    type_free(struct_of_three_ints);
+}
+
+int
+main(int argc, char** argv)
+{
+    init();
+
+    test_tag_type();
+    test_tag_size();
+
+    tidy();
+
+    return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach( testname
     03-tag_create
     04-metatag_lookup
     05-tag-locking
+    06-types
  )
     add_executable( ${testname} ${testname}.c )
     target_include_directories(${testname} PUBLIC


### PR DESCRIPTION
This patch introduces an associated type with every tag and uses
type information for simple checks like offset calculation and
out-of-bounds checks.

This patch also introduces loading types from an external file,
called `tags.inc`.  Currently I need to think through the
mechanism for arbitrary types, but James and I have discussed
"flattening" out complex types, which this is certainly sufficient
for.

This required applying a double-bladed lightsabre to this code,
so the end result is not as tidy.  There will be other patches
to decouple tag IDs from tags which will further mess things up;
once those are in I will come back and tidy stuff up.