### PR TITLE
Correct order of arguments to memset

### DIFF
--- a/src/tagtree.c
+++ b/src/tagtree.c
@@ -150,7 +150,7 @@ tag_tree_node_create(const char* name, type_t type)
     if (tag->data == NULL) {
         err(1, "malloc");
     }
-    memset(tag->data, sz, 0x42);
+    memset(tag->data, 0x42, sz);
 
     tag->tag_id = id;
     RB_INSERT(tag_tree_t, &tag_tree, tag);


### PR DESCRIPTION
* Fixes segfault

I tried to write a test for this, and even with ~200kb arrays I wasn't able to trigger this issue, but it showed up when using the current version of the stub against the plant structures (probably due to allocation patterns, or what was being overwritten).